### PR TITLE
Undocking bounds control

### DIFF
--- a/demo/src/pages/dockWindow/DockWindow.module.css
+++ b/demo/src/pages/dockWindow/DockWindow.module.css
@@ -15,3 +15,8 @@
 .buttonDock {
     margin-right: var(--margin-small);
 }
+
+.smallInput {
+    width: 45px;
+    margin: 0 5px;
+}

--- a/demo/src/pages/dockWindow/DockWindow.tsx
+++ b/demo/src/pages/dockWindow/DockWindow.tsx
@@ -38,8 +38,25 @@ const DockWindow: React.FC = () => {
     const [win, setWin] = useState();
     const [enableStretchToFit, setEnableStretchToFit] = useState(false);
     const [allowUndocking, setAllowUndocking] = useState(true);
-    const [edge, actions] = useDockWindow(ScreenEdge.NONE, win || window.fin.Window.getCurrentSync(),
-        allowUndocking, enableStretchToFit ? dimensions : undefined);
+    const [undockWidth, setUndockWidth] = useState();
+    const [undockHeight, setUndockHeight] = useState();
+    const [undockTop, setUndockTop] = useState();
+    const [undockLeft, setUndockLeft] = useState();
+    const [update, setUpdate] = useState(false);
+    const [edge, actions] = useDockWindow(
+        ScreenEdge.NONE,
+        win || window.fin.Window.getCurrentSync(),
+        allowUndocking,
+        enableStretchToFit ? dimensions : undefined,
+        {
+            undockPosition: undockTop && undockLeft
+                ? { top: undockTop, left: undockLeft }
+                : undefined,
+            undockSize: undockWidth && undockHeight
+                ? { width: undockWidth, height: undockHeight }
+                : undefined,
+        },
+    );
 
     useEffect(() => {
         let newWindow: _Window;
@@ -58,13 +75,12 @@ const DockWindow: React.FC = () => {
         };
 
         createWindow();
-
         return () => {
             if (newWindow) {
                 newWindow.close();
             }
         };
-    }, [allowUndocking, enableStretchToFit]);
+    }, [allowUndocking, enableStretchToFit, update]);
 
     useEffect(Prism.highlightAll, []);
 
@@ -100,6 +116,39 @@ const DockWindow: React.FC = () => {
                     <button type="button" onClick={actions.dockRight} className={styles.buttonDock}>Right</button>
                     <button type="button" onClick={actions.dockBottom} className={styles.buttonDock}>Bottom</button>
                     <button type="button" onClick={actions.dockNone} className={styles.buttonDock}>None</button>
+                </div>
+                <div>
+                    <h3>Undock size</h3>
+                    <span>width:</span>
+                    <input
+                        type="number"
+                        value={undockWidth}
+                        onChange={(e) => setUndockWidth(e.target.value ? Number(e.target.value) : undefined)}
+                        className={styles.smallInput}
+                    />
+                    <span>height:</span>
+                    <input type="number"
+                        value={undockHeight}
+                        onChange={(e) => setUndockHeight(e.target.value ? Number(e.target.value) : undefined)}
+                        className={styles.smallInput}
+                    />
+                    <button onClick={() => setUpdate(!update)}>Update</button>
+                </div>
+                <div>
+                    <h3>Undock position</h3>
+                    <span>top:</span>
+                    <input type="number"
+                        value={undockTop}
+                        onChange={(e) => setUndockTop(e.target.value ? Number(e.target.value) : undefined)}
+                        className={styles.smallInput}
+                    />
+                    <span>left:</span>
+                    <input type="number"
+                        value={undockLeft}
+                        onChange={(e) => setUndockLeft(e.target.value ? Number(e.target.value) : undefined)}
+                        className={styles.smallInput}
+                    />
+                    <button onClick={() => setUpdate(!update)}>Update</button>
                 </div>
                 <div>
                     <h3>Current docked state</h3>

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,17 @@ export interface IDimensions {
     dockedHeight: number;
 }
 
+export interface IUseDockWindowOptions {
+    undockPosition?: {
+        left: number;
+        top: number;
+    };
+    undockSize?: {
+        height: number;
+        width: number;
+    };
+}
+
 export interface IChannelAction {
   topic: string;
   action: Action;
@@ -32,7 +43,8 @@ export const useChannelProvider: (channelName: string, channelActions: IChannelA
 export const useDocked: () => [boolean, () => Promise<void>];
 
 export const useDockWindow: (initialEdge?: ScreenEdge, toMove?: _Window, allowUserToUndock?: boolean,
-                             stretchToFit?: IDimensions) => [ScreenEdge, {
+                             stretchToFit?: IDimensions,
+                             options?: IUseDockWindowOptions) => [ScreenEdge, {
     dockBottom: () => void;
     dockLeft: () => void;
     dockNone: () => void;

--- a/src/useDockWindow.transitions.ts
+++ b/src/useDockWindow.transitions.ts
@@ -2,41 +2,96 @@ import {Rect} from "openfin/_v2/api/system/monitor";
 import Bounds from "openfin/_v2/api/window/bounds";
 import {Transition} from "openfin/_v2/api/window/transition";
 
-import {IDimensions} from "../index";
+import {IDimensions, IUseDockWindowOptions} from "../index";
 import {ScreenEdge} from "./ScreenEdge";
 
 const ANIMATION_DURATION: number = 250;
 const UNDOCK_MARGIN: number = 25;
 
-const stretchedUndock = (previous: ScreenEdge, monitorBounds: Rect, stretchToFit: IDimensions): Transition => ({
-    position: {
-        duration: ANIMATION_DURATION,
-        left: previous !== ScreenEdge.RIGHT ?
-            monitorBounds.left + UNDOCK_MARGIN : monitorBounds.right - stretchToFit.dockedWidth - UNDOCK_MARGIN,
-        relative: false,
-        top: previous !== ScreenEdge.BOTTOM ? monitorBounds.top + UNDOCK_MARGIN :
-            monitorBounds.bottom - stretchToFit.dockedHeight - UNDOCK_MARGIN,
-    },
-    size: {
-        duration: ANIMATION_DURATION,
-        height: previous === ScreenEdge.LEFT || previous === ScreenEdge.RIGHT ?
-            monitorBounds.bottom - monitorBounds.top - (UNDOCK_MARGIN * 2) : stretchToFit.dockedHeight,
-        relative: false,
-        width: previous === ScreenEdge.TOP || previous === ScreenEdge.BOTTOM ?
-            monitorBounds.right - monitorBounds.left - (UNDOCK_MARGIN * 2) : stretchToFit.dockedWidth,
-    },
-});
+const stretchedUndock = (previous: ScreenEdge, monitorBounds: Rect, stretchToFit: IDimensions,
+                         options?: IUseDockWindowOptions): Transition => {
+    const width = options && options.undockSize
+        ? options.undockSize.width
+        : (
+            previous === ScreenEdge.TOP || previous === ScreenEdge.BOTTOM
+                ? monitorBounds.right - monitorBounds.left - (UNDOCK_MARGIN * 2)
+                : stretchToFit.dockedWidth
+        );
+    const height = options && options.undockSize
+        ? options.undockSize.height
+        : (
+            previous === ScreenEdge.LEFT || previous === ScreenEdge.RIGHT
+                ? monitorBounds.bottom - monitorBounds.top - (UNDOCK_MARGIN * 2)
+                : stretchToFit.dockedHeight
+        );
+    const top = options && options.undockPosition
+        ? options.undockPosition.top
+        : (
+            previous !== ScreenEdge.BOTTOM
+                ? monitorBounds.top + UNDOCK_MARGIN
+                : monitorBounds.bottom - height - UNDOCK_MARGIN
+        );
+    const left = options && options.undockPosition
+        ? options.undockPosition.left
+        : (
+            previous !== ScreenEdge.RIGHT ?
+                monitorBounds.left + UNDOCK_MARGIN :
+                monitorBounds.right - width - UNDOCK_MARGIN
+        );
 
-const undock = (previous: ScreenEdge, windowBounds: Bounds): Transition => ({
-    position: {
-        duration: ANIMATION_DURATION,
-        left: previous === ScreenEdge.LEFT ? windowBounds.left + UNDOCK_MARGIN : previous === ScreenEdge.RIGHT ?
-            windowBounds.left - UNDOCK_MARGIN : windowBounds.left,
-        relative: false,
-        top: previous === ScreenEdge.TOP ? windowBounds.top + UNDOCK_MARGIN : previous === ScreenEdge.BOTTOM ?
-            windowBounds.top - UNDOCK_MARGIN : windowBounds.top,
-    },
-});
+    return {
+        position: {
+            duration: ANIMATION_DURATION,
+            left,
+            relative: false,
+            top,
+        },
+        size: {
+            duration: ANIMATION_DURATION,
+            height,
+            relative: false,
+            width,
+        },
+    };
+};
+
+const undock = (previous: ScreenEdge, windowBounds: Bounds, options?: IUseDockWindowOptions): Transition => {
+    const width = options && options.undockSize ? options.undockSize.width : windowBounds.width;
+    const height = options && options.undockSize ? options.undockSize.height : windowBounds.height;
+    const top = options && options.undockPosition
+        ? options.undockPosition.top
+        : (
+            previous === ScreenEdge.TOP
+                ? windowBounds.top + UNDOCK_MARGIN
+                : previous === ScreenEdge.BOTTOM
+                    ? windowBounds.top - UNDOCK_MARGIN
+                    : windowBounds.top
+        );
+    const left = options && options.undockPosition
+        ? options.undockPosition.left
+        : (
+            previous === ScreenEdge.LEFT
+                ? windowBounds.left + UNDOCK_MARGIN
+                : previous === ScreenEdge.RIGHT
+                    ? windowBounds.left - UNDOCK_MARGIN
+                    : windowBounds.left
+        );
+
+    return {
+        position: {
+            duration: ANIMATION_DURATION,
+            left,
+            relative: false,
+            top,
+        },
+        size: {
+            duration: ANIMATION_DURATION,
+            height,
+            relative: false,
+            width,
+        },
+    };
+};
 
 const stretchedDock = (current: ScreenEdge, monitorBounds: Rect, stretchToFit: IDimensions): Transition => ({
     position: {

--- a/src/useDockWindow.ts
+++ b/src/useDockWindow.ts
@@ -4,7 +4,7 @@ import {Transition} from "openfin/_v2/api/window/transition";
 import {_Window} from "openfin/_v2/api/window/window";
 import {useEffect, useState} from "react";
 
-import {IDimensions} from "../index";
+import {IDimensions, IUseDockWindowOptions} from "../index";
 import {ScreenEdge} from "./ScreenEdge";
 import transitions from "./useDockWindow.transitions";
 import usePreviousValue from "./utils/usePreviousValue";
@@ -22,7 +22,8 @@ const getMonitorRect = async (bounds: Bounds): Promise<Rect> => {
 };
 
 export default (initialEdge = ScreenEdge.NONE, toMove: _Window = fin.Window.getCurrentSync(),
-                allowUserToUndock: boolean = true, stretchToFit?: IDimensions) => {
+                allowUserToUndock: boolean = true, stretchToFit?: IDimensions,
+                options?: IUseDockWindowOptions) => {
     const [edge, setEdge] = useState(initialEdge);
     const [isUndocking, setIsUndocking] = useState(false);
     const previousEdge = usePreviousValue<ScreenEdge>(edge);
@@ -88,8 +89,8 @@ export default (initialEdge = ScreenEdge.NONE, toMove: _Window = fin.Window.getC
             const bounds: Bounds = await toMove.getBounds();
             const monitorRect: Rect = await getMonitorRect(bounds);
             const transition: Transition = stretchToFit ?
-                transitions.stretchedUndock(previousEdge!, monitorRect, stretchToFit) :
-                transitions.undock(previousEdge!, bounds);
+                transitions.stretchedUndock(previousEdge!, monitorRect, stretchToFit, options) :
+                transitions.undock(previousEdge!, bounds, options);
 
             await toMove.animate(transition, { interrupt: true });
             setIsUndocking(false);


### PR DESCRIPTION
This PR adds optional, finer-grained control over the undocking behaviour in the `useDockWindow` hook. I've added a more generic "options" argument to hook's parameters which could potentially be extended to add further new behaviour to the hook in the future without breaking existing functionality. Specifically, the developer can specify the `undockSize` (comprised of a `width` and `height` - both must be specified for it to be taken into account) and the `undockPosition` (comprised of `top` and `left` - both must be specified for it to be taken into account) options to control the bounds of the window that is undocked.

I've updated the demo page with a quick example, but that can probably be improved further. I haven't had a chance to update the readme or code sample on the demo page just yet. If anyone would like to make those changes before merging this PR, then feel free.

Thanks!